### PR TITLE
Add caching support for ELNormalizer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+- Added caching support for `ELNormalizer`: normalized ontologies can now be saved to disk and loaded on subsequent runs, significantly speeding up repeated normalization of the same ontology.
+- Added `ontology_path` and `use_cache` parameters to `ELNormalizer.normalize()` and `ELDataset`.
+- `EmbeddingELModel` now automatically uses caching when the dataset provides ontology paths (e.g., `PathDataset`).
 - Added tests for EL models (ELBE, ELBEPPI, ELBEGDA, ELEmGDA, BoxSquaredEL)
 ### Fixed
 - ELBEPPI now automatically sets PPIEvaluator in `__init__`, matching ELEmPPI behavior

--- a/mowl/base_models/elmodel.py
+++ b/mowl/base_models/elmodel.py
@@ -77,12 +77,18 @@ merging the 3 extra to their corresponding origin normal forms. Defaults to True
         if self._datasets_loaded:
             return
 
+        # Get ontology paths for caching if available (PathDataset provides these)
+        ontology_path = getattr(self.dataset, 'ontology_path', None)
+        validation_path = getattr(self.dataset, 'validation_path', None)
+        testing_path = getattr(self.dataset, 'testing_path', None)
+
         training_el_dataset = ELDataset(self.dataset.ontology,
                                         self.class_index_dict,
                                         self.object_property_index_dict,
                                         extended=self._extended,
-                                        load_normalized = self.load_normalized,
-                                        device=self.device)
+                                        load_normalized=self.load_normalized,
+                                        device=self.device,
+                                        ontology_path=ontology_path)
 
         self._training_datasets = training_el_dataset.get_gci_datasets()
 
@@ -90,7 +96,8 @@ merging the 3 extra to their corresponding origin normal forms. Defaults to True
         if self.dataset.validation:
             validation_el_dataset = ELDataset(self.dataset.validation, self.class_index_dict,
                                               self.object_property_index_dict,
-                                              extended=self._extended, device=self.device)
+                                              extended=self._extended, device=self.device,
+                                              ontology_path=validation_path)
 
             self._validation_datasets = validation_el_dataset.get_gci_datasets()
 
@@ -98,7 +105,8 @@ merging the 3 extra to their corresponding origin normal forms. Defaults to True
         if self.dataset.testing:
             testing_el_dataset = ELDataset(self.dataset.testing, self.class_index_dict,
                                            self.object_property_index_dict,
-                                           extended=self._extended, device=self.device)
+                                           extended=self._extended, device=self.device,
+                                           ontology_path=testing_path)
 
             self._testing_datasets = testing_el_dataset.get_gci_datasets()
 

--- a/tests/datasets/test_el_dataset.py
+++ b/tests/datasets/test_el_dataset.py
@@ -42,6 +42,12 @@ must be of type dict"):
         with self.assertRaisesRegex(TypeError, "Optional parameter device must be of type str"):
             ELDataset(self.dataset_family.ontology, device=1)
 
+        with self.assertRaisesRegex(TypeError, "Optional parameter ontology_path must be of type str"):
+            ELDataset(self.dataset_family.ontology, ontology_path=123)
+
+        with self.assertRaisesRegex(TypeError, "Optional parameter use_cache must be of type bool"):
+            ELDataset(self.dataset_family.ontology, use_cache="yes")
+
     def test_extended_parameter_false(self):
         """This should check if the extended parameter works as expected when set to false"""
 


### PR DESCRIPTION
Normalized ontologies can now be saved to disk and loaded on subsequent runs, significantly speeding up repeated normalization of the same ontology.

Changes:
- Add get_cache_path(), _save_normalized_ontology(), _load_cached_ontology() methods to ELNormalizer
- Add ontology_path and use_cache parameters to ELNormalizer.normalize()
- Add ontology_path and use_cache parameters to ELDataset
- Update EmbeddingELModel to automatically use caching when dataset provides ontology paths (e.g., PathDataset)
- Add tests for caching functionality