### PR TITLE
Refactor EL models with standardized training loop

### DIFF
--- a/mowl/base_models/elmodel.py
+++ b/mowl/base_models/elmodel.py
@@ -4,6 +4,7 @@ from mowl.datasets.el import ELDataset
 from mowl.projection import projector_factory
 import torch as th
 from torch.utils.data import DataLoader, default_collate
+from tqdm import trange
 
 from deprecated.sphinx import versionadded, versionchanged
 
@@ -13,6 +14,11 @@ import copy
 import numpy as np
 import mowl.error.messages as msg
 import os
+import logging
+
+logger = logging.getLogger(__name__)
+logger.addHandler(logging.StreamHandler())
+logger.setLevel(logging.INFO)
 
 @versionchanged(version="1.0.0", reason="Added the 'load_normalized' parameter.")
 class EmbeddingELModel(Model):
@@ -35,12 +41,13 @@ merging the 3 extra to their corresponding origin normal forms. Defaults to True
     :type device: str, optional
     """
 
-    def __init__(self, dataset, embed_dim, batch_size, extended=True, model_filepath=None, load_normalized=False, device="cpu"):
+    def __init__(self, dataset, embed_dim, batch_size, extended=True, model_filepath=None,
+                 load_normalized=False, device="cpu", learning_rate=0.001):
         super().__init__(dataset, model_filepath=model_filepath)
 
         if not isinstance(embed_dim, int):
             raise TypeError("Parameter 'embed_dim' must be of type int.")
-        
+
         if not isinstance(batch_size, int):
             raise TypeError("Parameter batch_size must be of type int.")
 
@@ -49,7 +56,7 @@ merging the 3 extra to their corresponding origin normal forms. Defaults to True
 
         if not isinstance(load_normalized, bool):
             raise TypeError("Optional parameter load_normalized must be of type bool.")
-        
+
         if not isinstance(device, str):
             raise TypeError("Optional parameter device must be of type str.")
 
@@ -60,7 +67,8 @@ merging the 3 extra to their corresponding origin normal forms. Defaults to True
         self.batch_size = batch_size
         self.device = device
         self.load_normalized = load_normalized
-        
+        self.learning_rate = learning_rate
+
         self._training_datasets = None
         self._validation_datasets = None
         self._testing_datasets = None
@@ -205,6 +213,227 @@ of :class:`torch.utils.data.DataLoader`
 
         self._load_dataloaders()
         return self._testing_dataloaders
+
+    # ==================== Training Methods ====================
+
+    def get_negative_sampling_config(self):
+        """Returns configuration for negative sampling.
+
+        Override this method to customize which GCI types require negative sampling
+        and how negatives should be generated.
+
+        :return: Dictionary mapping GCI names to their negative sampling config.
+            Each config should have:
+            - 'index_pool': str, either 'classes' or 'individuals'
+            - 'corrupt_column': int, which column to corrupt with random indices
+        :rtype: dict
+
+        Example::
+
+            {
+                "gci2": {"index_pool": "classes", "corrupt_column": 2},
+                "object_property_assertion": {"index_pool": "individuals", "corrupt_column": 2}
+            }
+        """
+        return {
+            "gci2": {"index_pool": "classes", "corrupt_column": 2},
+            "object_property_assertion": {"index_pool": "individuals", "corrupt_column": 2}
+        }
+
+    def generate_negatives(self, gci_name, gci_dataset):
+        """Generate negative samples for a given GCI type.
+
+        Override this method for custom negative sampling strategies.
+
+        :param gci_name: Name of the GCI type (e.g., 'gci2')
+        :type gci_name: str
+        :param gci_dataset: The dataset containing positive samples
+        :type gci_dataset: torch.Tensor
+        :return: Negative samples tensor, or None if no negatives for this GCI type
+        :rtype: torch.Tensor or None
+        """
+        config = self.get_negative_sampling_config()
+        if gci_name not in config:
+            return None
+
+        cfg = config[gci_name]
+        index_pool = cfg["index_pool"]
+        corrupt_column = cfg["corrupt_column"]
+
+        if index_pool == "classes":
+            all_ids = list(self.class_index_dict.values())
+        elif index_pool == "individuals":
+            all_ids = list(self.individual_index_dict.values())
+        else:
+            raise ValueError(f"Unknown index_pool: {index_pool}")
+
+        data = gci_dataset[:]
+        idxs_for_negs = np.random.choice(all_ids, size=len(gci_dataset), replace=True)
+        rand_index = th.tensor(idxs_for_negs, dtype=th.long, device=self.device)
+
+        # Build negative data by replacing the specified column
+        neg_data = th.cat([data[:, :corrupt_column], rand_index.unsqueeze(1)], dim=1)
+        if corrupt_column + 1 < data.shape[1]:
+            neg_data = th.cat([neg_data, data[:, corrupt_column + 1:]], dim=1)
+
+        return neg_data
+
+    def compute_loss(self, pos_scores, neg_scores=None):
+        """Compute loss from positive and negative scores.
+
+        Override this method to use different loss functions (e.g., MSE loss).
+
+        :param pos_scores: Scores for positive samples (should be minimized)
+        :type pos_scores: torch.Tensor
+        :param neg_scores: Scores for negative samples (should be maximized), or None
+        :type neg_scores: torch.Tensor or None
+        :return: Combined loss value
+        :rtype: torch.Tensor
+        """
+        loss = th.mean(pos_scores)
+        if neg_scores is not None:
+            loss += th.mean(neg_scores)
+        return loss
+
+    def get_regularization_loss(self):
+        """Get regularization loss from the module.
+
+        Override this method if your module has a regularization loss.
+
+        :return: Regularization loss value
+        :rtype: torch.Tensor
+        """
+        if hasattr(self.module, 'regularization_loss'):
+            return self.module.regularization_loss()
+        return 0
+
+    def get_optimizer(self):
+        """Create and return the optimizer.
+
+        Override this method to use a different optimizer or configuration.
+
+        :return: Optimizer instance
+        :rtype: torch.optim.Optimizer
+        """
+        return th.optim.Adam(self.module.parameters(), lr=self.learning_rate)
+
+    def train(self, epochs, validate_every=1):
+        """Train the model.
+
+        This is the generic training loop for EL embedding models. Subclasses can
+        customize behavior by overriding:
+        - :meth:`get_negative_sampling_config`: Configure which GCIs need negatives
+        - :meth:`generate_negatives`: Custom negative sampling strategy
+        - :meth:`compute_loss`: Custom loss computation (e.g., MSE loss)
+        - :meth:`get_regularization_loss`: Add regularization
+        - :meth:`get_optimizer`: Use different optimizer
+
+        :param epochs: Number of training epochs
+        :type epochs: int
+        :param validate_every: Validate and log every N epochs. Defaults to 1.
+        :type validate_every: int, optional
+        """
+        logger.warning(
+            'You are using the default training method. If you want to use a customized '
+            'training method (e.g., different negative sampling, etc.), please override '
+            'the appropriate methods in a subclass.'
+        )
+
+        # Log dataset sizes
+        points_per_dataset = {k: len(v) for k, v in self.training_datasets.items()}
+        string = "Training datasets: \n"
+        for k, v in points_per_dataset.items():
+            string += f"\t{k}: {v}\n"
+        logger.info(string)
+
+        optimizer = self.get_optimizer()
+        best_loss = float('inf')
+
+        for epoch in trange(epochs):
+            self.module.train()
+
+            train_loss = 0
+            loss = th.tensor(0.0, device=self.device)
+
+            for gci_name, gci_dataset in self.training_datasets.items():
+                if len(gci_dataset) == 0:
+                    continue
+
+                # Compute positive loss
+                pos_scores = self.module(gci_dataset[:], gci_name)
+
+                # Generate and compute negative loss if applicable
+                neg_data = self.generate_negatives(gci_name, gci_dataset)
+                neg_scores = None
+                if neg_data is not None:
+                    neg_scores = self.module(neg_data, gci_name, neg=True)
+
+                loss = loss + self.compute_loss(pos_scores, neg_scores)
+
+            # Add regularization loss
+            loss = loss + self.get_regularization_loss()
+
+            optimizer.zero_grad()
+            loss.backward()
+            optimizer.step()
+            train_loss += loss.detach().item()
+
+            # Validation
+            if (epoch + 1) % validate_every == 0:
+                if self.dataset.validation is not None:
+                    with th.no_grad():
+                        self.module.eval()
+                        valid_loss = 0
+                        gci2_data = self.validation_datasets["gci2"][:]
+                        vloss = th.mean(self.module(gci2_data, "gci2"))
+                        valid_loss += vloss.detach().item()
+
+                        if valid_loss < best_loss:
+                            best_loss = valid_loss
+                            th.save(self.module.state_dict(), self.model_filepath)
+                    print(f'Epoch {epoch+1}: Train loss: {train_loss} Valid loss: {valid_loss}')
+                else:
+                    print(f'Epoch {epoch+1}: Train loss: {train_loss}')
+
+    def eval_method(self, data):
+        """Evaluation method used for scoring. Override if needed.
+
+        :param data: Input data for evaluation
+        :type data: torch.Tensor
+        :return: Evaluation scores
+        :rtype: torch.Tensor
+        """
+        return self.module.gci2_loss(data)
+
+    def get_embeddings(self):
+        """Get trained embeddings for entities, relations, and individuals.
+
+        :return: Tuple of (entity_embeddings, relation_embeddings, individual_embeddings)
+        :rtype: tuple
+        """
+        self.init_module()
+        print('Load the best model', self.model_filepath)
+        self.load_best_model()
+
+        ent_embeds = {
+            k: v for k, v in zip(self.class_index_dict.keys(),
+                                 self.module.class_embed.weight.cpu().detach().numpy())}
+        rel_embeds = {
+            k: v for k, v in zip(self.object_property_index_dict.keys(),
+                                 self.module.rel_embed.weight.cpu().detach().numpy())}
+        if self.module.ind_embed is not None:
+            ind_embeds = {
+                k: v for k, v in zip(self.individual_index_dict.keys(),
+                                     self.module.ind_embed.weight.cpu().detach().numpy())}
+        else:
+            ind_embeds = None
+        return ent_embeds, rel_embeds, ind_embeds
+
+    def load_best_model(self):
+        """Load the best model from the model filepath."""
+        self.init_module()
+        self.module.load_state_dict(th.load(self.model_filepath, weights_only=True))
+        self.module.eval()
 
     @versionadded(version="0.2.0")
     def score(self, axiom):

--- a/mowl/models/__init__.py
+++ b/mowl/models/__init__.py
@@ -2,7 +2,7 @@ from mowl.models.elembeddings.model import ELEmbeddings
 from mowl.models.elembeddings.examples.model_ppi import ELEmPPI
 from mowl.models.elembeddings.examples.model_gda import ELEmGDA
 
-from mowl.models.elbe.model import ELBoxEmbeddings, ELBE
+from mowl.models.elbe.model import ELBE
 from mowl.models.elbe.examples.model_ppi import ELBEPPI
 from mowl.models.elbe.examples.model_gda import ELBEGDA
 

--- a/mowl/models/boxsquaredel/examples/model_gda.py
+++ b/mowl/models/boxsquaredel/examples/model_gda.py
@@ -9,6 +9,10 @@ class BoxSquaredELGDA(BoxSquaredEL):
     with regularization inherited from BoxSquaredEL.
     """
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.eval_gci_name = "gci2"
+
     def get_negative_sampling_config(self):
         """Only do negative sampling for gci2."""
         return {

--- a/mowl/models/boxsquaredel/examples/model_gda.py
+++ b/mowl/models/boxsquaredel/examples/model_gda.py
@@ -1,12 +1,12 @@
-from mowl.models import ELEmbeddings
+from mowl.models import BoxSquaredEL
 
 
-class ELEmGDA(ELEmbeddings):
+class BoxSquaredELGDA(BoxSquaredEL):
     """
-    Example of ELEmbeddings for gene-disease associations prediction.
+    Example of BoxSquaredEL for gene-disease associations prediction.
 
     Uses default negative sampling (all classes for gci2) and direct loss
-    with regularization inherited from ELEmbeddings.
+    with regularization inherited from BoxSquaredEL.
     """
 
     def get_negative_sampling_config(self):
@@ -14,3 +14,8 @@ class ELEmGDA(ELEmbeddings):
         return {
             "gci2": {"index_pool": "classes", "corrupt_column": 2}
         }
+
+
+# Backward compatibility alias
+ELBoxGDA = BoxSquaredELGDA
+

--- a/mowl/models/boxsquaredel/examples/model_ppi.py
+++ b/mowl/models/boxsquaredel/examples/model_ppi.py
@@ -1,21 +1,21 @@
-from mowl.models import ELBE
+from mowl.models import BoxSquaredEL
 from mowl.evaluation import PPIEvaluator
 import torch as th
 import numpy as np
 
 
-class ELBEPPI(ELBE):
+class BoxSquaredELPPI(BoxSquaredEL):
     """
-    Example of ELBE for protein-protein interaction prediction.
+    Example of BoxSquaredEL for protein-protein interaction prediction.
 
     This model customizes negative sampling to use only protein IDs
-    from the evaluation classes instead of all ontology classes.
+    from the evaluation classes and generates multiple negatives per positive
+    using the num_negs parameter.
     """
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.set_evaluator(PPIEvaluator)
-        # Cache protein IDs for negative sampling
         self._protein_ids = None
 
     @property
@@ -35,22 +35,27 @@ class ELBEPPI(ELBE):
         return self._evaluation_model
 
     def get_negative_sampling_config(self):
-        """Only do negative sampling for gci2 (not object_property_assertion)."""
+        """Only do negative sampling for gci2."""
         return {
             "gci2": {"corrupt_column": 2}
         }
 
     def generate_negatives(self, gci_name, gci_dataset):
-        """Generate negatives using only protein IDs for gci2."""
+        """Generate multiple negatives per positive using protein IDs."""
         if gci_name != "gci2":
             return None
 
         data = gci_dataset[:]
+        # Generate num_negs negatives per positive sample
         idxs_for_negs = np.random.choice(
-            self.protein_ids, size=len(gci_dataset), replace=True
+            self.protein_ids, size=(self.num_negs, len(data)), replace=True
         )
         rand_index = th.tensor(idxs_for_negs, dtype=th.long, device=self.device)
-        neg_data = th.cat([data[:, :2], rand_index.unsqueeze(1)], dim=1)
+        rand_index = rand_index.reshape(-1)
+
+        # Repeat positive data to match negatives
+        data_repeated = data.repeat(self.num_negs, 1)
+        neg_data = th.cat([data_repeated[:, :2], rand_index.unsqueeze(1)], dim=1)
         return neg_data
 
     def evaluate_ppi(self):
@@ -59,7 +64,5 @@ class ELBEPPI(ELBE):
         print("Load the best model", self.model_filepath)
         self.load_best_model()
         with th.no_grad():
-            self.evaluate(
-                self.dataset.testing, filter_ontologies=[self.dataset.ontology]
-            )
-            print(self.metrics)
+            metrics = self.evaluate()
+            print(metrics)

--- a/mowl/models/boxsquaredel/examples/model_ppi.py
+++ b/mowl/models/boxsquaredel/examples/model_ppi.py
@@ -16,6 +16,7 @@ class BoxSquaredELPPI(BoxSquaredEL):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.set_evaluator(PPIEvaluator)
+        self.eval_gci_name = "gci2"
         self._protein_ids = None
 
     @property

--- a/mowl/models/boxsquaredel/model.py
+++ b/mowl/models/boxsquaredel/model.py
@@ -1,14 +1,5 @@
 from mowl.base_models.elmodel import EmbeddingELModel
 from mowl.nn import BoxSquaredELModule
-from tqdm import trange, tqdm
-import torch as th
-import numpy as np
-import logging
-
-logger = logging.getLogger(__name__)
-handler = logging.StreamHandler()
-logger.addHandler(handler)
-logger.setLevel(logging.INFO)
 
 
 class BoxSquaredEL(EmbeddingELModel):
@@ -22,7 +13,6 @@ class BoxSquaredEL(EmbeddingELModel):
                  margin=0.02,
                  reg_norm=1,
                  learning_rate=0.001,
-                 epochs=1000,
                  batch_size=4096 * 8,
                  delta=2.5,
                  reg_factor=0.2,
@@ -30,16 +20,15 @@ class BoxSquaredEL(EmbeddingELModel):
                  model_filepath=None,
                  device='cpu'
                  ):
-        super().__init__(dataset, embed_dim, batch_size, extended=True, model_filepath=model_filepath)
+        super().__init__(dataset, embed_dim, batch_size, extended=True,
+                         model_filepath=model_filepath, device=device,
+                         learning_rate=learning_rate)
 
         self.margin = margin
         self.reg_norm = reg_norm
         self.delta = delta
         self.reg_factor = reg_factor
         self.num_negs = num_negs
-        self.learning_rate = learning_rate
-        self.epochs = epochs
-        self.device = device
         self._loaded = False
         self.extended = False
         self.init_module()
@@ -53,104 +42,5 @@ class BoxSquaredEL(EmbeddingELModel):
             gamma=self.margin,
             delta=self.delta,
             reg_factor=self.reg_factor
-
         ).to(self.device)
-
-    def train(self, epochs=None, validate_every=1):
-        logger.warning('You are using the default training method. If you want to use a cutomized training method (e.g., different negative sampling, etc.), please reimplement the train method in a subclass.')
-
-        points_per_dataset = {k: len(v) for k, v in self.training_datasets.items()}
-        string = "Training datasets: \n"
-        for k, v in points_per_dataset.items():
-            string += f"\t{k}: {v}\n"
-
-        logger.info(string)
-            
-        optimizer = th.optim.Adam(self.module.parameters(), lr=self.learning_rate)
-        best_loss = float('inf')
-
-        all_classes_ids = list(self.class_index_dict.values())
-        all_inds_ids = list(self.individual_index_dict.values())
-        
-        if epochs is None:
-            epochs = self.epochs
-        
-        for epoch in trange(epochs):
-            self.module.train()
-
-            train_loss = 0
-            loss = 0
-
-            for gci_name, gci_dataset in self.training_datasets.items():
-                if len(gci_dataset) == 0:
-                    continue
-
-                loss += th.mean(self.module(gci_dataset[:], gci_name))
-                if gci_name == "gci2":
-                    idxs_for_negs = np.random.choice(all_classes_ids, size=len(gci_dataset), replace=True)
-                    rand_index = th.tensor(idxs_for_negs).to(self.device)
-                    data = gci_dataset[:]
-                    neg_data = th.cat([data[:, :2], rand_index.unsqueeze(1)], dim=1)
-                    loss += th.mean(self.module(neg_data, gci_name, neg=True))
-
-                if gci_name == "object_property_assertion":
-                    idxs_for_negs = np.random.choice(all_inds_ids, size=len(gci_dataset), replace=True)
-                    rand_index = th.tensor(idxs_for_negs).to(self.device)
-                    data = gci_dataset[:]
-                    neg_data = th.cat([data[:, :2], rand_index.unsqueeze(1)], dim=1)
-                    loss += th.mean(self.module(neg_data, gci_name, neg=True))
-                    
-            loss += self.module.regularization_loss()
-                    
-            optimizer.zero_grad()
-            loss.backward()
-            optimizer.step()
-            train_loss += loss.detach().item()
-
-            loss = 0
-
-            if (epoch + 1) % validate_every == 0:
-                if self.dataset.validation is not None:
-                    with th.no_grad():
-                        self.module.eval()
-                        valid_loss = 0
-                        gci2_data = self.validation_datasets["gci2"][:]
-                        loss = th.mean(self.module(gci2_data, "gci2"))
-                        valid_loss += loss.detach().item()
-
-
-                        if valid_loss < best_loss:
-                            best_loss = valid_loss
-                            th.save(self.module.state_dict(), self.model_filepath)
-                    print(f'Epoch {epoch+1}: Train loss: {train_loss} Valid loss: {valid_loss}')
-                else:
-                    print(f'Epoch {epoch+1}: Train loss: {train_loss}')
- 
-    def eval_method(self, data):
-        return self.module.gci2_loss(data)
-
-    def get_embeddings(self):
-        self.init_module()
-
-        print('Load the best model', self.model_filepath)
-        self.load_best_model()
-                
-        ent_embeds = {
-            k: v for k, v in zip(self.class_index_dict.keys(),
-                                 self.module.class_embed.weight.cpu().detach().numpy())}
-        rel_embeds = {
-            k: v for k, v in zip(self.object_property_index_dict.keys(),
-                                 self.module.rel_embed.weight.cpu().detach().numpy())}
-        if self.module.ind_embed is not None:
-            ind_embeds = {
-                k: v for k, v in zip(self.individual_index_dict.keys(),
-                                     self.module.ind_embed.weight.cpu().detach().numpy())}
-        else:
-            ind_embeds = None
-        return ent_embeds, rel_embeds, ind_embeds
-
-    def load_best_model(self):
-        self.init_module()
-        self.module.load_state_dict(th.load(self.model_filepath))
-        self.module.eval()
 

--- a/mowl/models/elbe/examples/model_gda.py
+++ b/mowl/models/elbe/examples/model_gda.py
@@ -1,84 +1,17 @@
 from mowl.models import ELBE
 
-from mowl.projection.factory import projector_factory
-from mowl.projection.edge import Edge
-import math
-import logging
-import numpy as np
-
-from tqdm import trange, tqdm
-
-import torch as th
-from torch import nn
-
 
 class ELBEGDA(ELBE):
     """
-    Example of ELBoxEmbeddings for gene-disease associations prediction.
+    Example of ELBE for gene-disease associations prediction.
+
+    Uses default negative sampling (all classes for gci2) and MSE loss
+    inherited from ELBE.
     """
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        
-    def train(self):
-        _, diseases = self.dataset.evaluation_classes
 
-        criterion = nn.MSELoss()
-        optimizer = th.optim.Adam(self.module.parameters(), lr=self.learning_rate)
-        best_loss = float('inf')
+    def get_negative_sampling_config(self):
+        """Only do negative sampling for gci2."""
+        return {
+            "gci2": {"index_pool": "classes", "corrupt_column": 2}
+        }
 
-        training_datasets = {k: v.data for k, v in
-                             self.training_datasets.items()}
-        validation_dataset = self.validation_datasets["gci2"][:]
-
-        for epoch in trange(self.epochs):
-            self.module.train()
-
-            train_loss = 0
-            loss = 0
-
-            for gci_name, gci_dataset in training_datasets.items():
-                if len(gci_dataset) == 0:
-                    continue
-                rand_index = np.random.choice(len(gci_dataset), size=self.batch_size)
-                dst = self.module(gci_dataset[rand_index], gci_name)
-                mse_loss = criterion(dst, th.zeros(dst.shape, requires_grad=False).to(self.device))
-                loss += mse_loss
-
-                if gci_name == "gci2":
-                    rand_index = np.random.choice(len(gci_dataset), size=self.batch_size)
-                    gci_batch = gci_dataset[rand_index]
-                    idxs_for_negs = np.random.choice(len(self.class_index_dict),
-                                                     size=len(gci_batch), replace=True)
-                    rand_dis_ids = th.tensor(idxs_for_negs).to(self.device)
-                    neg_data = th.cat([gci_batch[:, :2], rand_dis_ids.unsqueeze(1)], dim=1)
-
-                    dst = self.module(neg_data, gci_name, neg=True)
-                    mse_loss = criterion(dst, th.ones(dst.shape,
-                                                      requires_grad=False).to(self.device))
-                    loss += mse_loss
-
-            optimizer.zero_grad()
-            loss.backward()
-            optimizer.step()
-            train_loss += loss.detach().item()
-
-            with th.no_grad():
-                self.module.eval()
-                valid_loss = 0
-                gci2_data = validation_dataset
-
-                dst = self.module(gci2_data, "gci2")
-                loss = criterion(dst, th.zeros(dst.shape, requires_grad=False).to(self.device))
-                valid_loss += loss.detach().item()
-
-            checkpoint = 100
-            if best_loss > valid_loss and (epoch + 1) % checkpoint == 0:
-                best_loss = valid_loss
-                print("Saving model..")
-                th.save(self.module.state_dict(), self.model_filepath)
-            if (epoch + 1) % checkpoint == 0:
-                print(f'Epoch {epoch}: Train loss: {train_loss} Valid loss: {valid_loss}')
-
-        return 1
-
-    

--- a/mowl/models/elbe/examples/model_gda.py
+++ b/mowl/models/elbe/examples/model_gda.py
@@ -9,6 +9,10 @@ class ELBEGDA(ELBE):
     inherited from ELBE.
     """
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.eval_gci_name = "gci2"
+
     def get_negative_sampling_config(self):
         """Only do negative sampling for gci2."""
         return {

--- a/mowl/models/elbe/examples/model_ppi.py
+++ b/mowl/models/elbe/examples/model_ppi.py
@@ -15,6 +15,7 @@ class ELBEPPI(ELBE):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.set_evaluator(PPIEvaluator)
+        self.eval_gci_name = "gci2"
         # Cache protein IDs for negative sampling
         self._protein_ids = None
 

--- a/mowl/models/elbe/model.py
+++ b/mowl/models/elbe/model.py
@@ -1,19 +1,15 @@
 from mowl.base_models.elmodel import EmbeddingELModel
 from mowl.nn import ELBEModule
-from tqdm import trange, tqdm
 import torch as th
-import numpy as np
 from deprecated.sphinx import deprecated
-import logging
 
-logger = logging.getLogger(__name__)
-handler = logging.StreamHandler()
-logger.addHandler(handler)
-logger.setLevel(logging.INFO)
 
 class ELBE(EmbeddingELModel):
     """
     Implementation based on [peng2020]_.
+
+    This model uses MSE loss to train the embeddings, where positive samples
+    should have scores close to 0 and negative samples should have scores close to 1.
     """
 
     def __init__(self,
@@ -22,20 +18,19 @@ class ELBE(EmbeddingELModel):
                  margin=0,
                  reg_norm=1,
                  learning_rate=0.001,
-                 epochs=1000,
                  batch_size=4096 * 8,
                  model_filepath=None,
                  device='cpu'
                  ):
-        super().__init__(dataset, embed_dim, batch_size, extended=True, model_filepath=model_filepath)
+        super().__init__(dataset, embed_dim, batch_size, extended=True,
+                         model_filepath=model_filepath, device=device,
+                         learning_rate=learning_rate)
 
         self.margin = margin
         self.reg_norm = reg_norm
-        self.learning_rate = learning_rate
-        self.epochs = epochs
-        self.device = device
         self._loaded = False
         self.extended = False
+        self._mse_criterion = th.nn.MSELoss()
         self.init_module()
 
     def init_module(self):
@@ -47,110 +42,20 @@ class ELBE(EmbeddingELModel):
             margin=self.margin
         ).to(self.device)
 
-    def train(self, epochs=None, validate_every=1):
-        logger.warning('You are using the default training method. If you want to use a cutomized training method (e.g., different negative sampling, etc.), please reimplement the train method in a subclass.')
+    def compute_loss(self, pos_scores, neg_scores=None):
+        """Compute MSE loss for ELBE.
 
-        points_per_dataset = {k: len(v) for k, v in self.training_datasets.items()}
-        string = "Training datasets: \n"
-        for k, v in points_per_dataset.items():
-            string += f"\t{k}: {v}\n"
+        Positive samples should have scores close to 0.
+        Negative samples should have scores close to 1.
+        """
+        pos_mean = th.mean(pos_scores)
+        loss = self._mse_criterion(pos_mean, th.zeros_like(pos_mean, requires_grad=False))
 
-        logger.info(string)
-            
-        optimizer = th.optim.Adam(self.module.parameters(), lr=self.learning_rate)
-        criterion = th.nn.MSELoss()
-        best_loss = float('inf')
+        if neg_scores is not None:
+            neg_mean = th.mean(neg_scores)
+            loss += self._mse_criterion(neg_mean, th.ones_like(neg_mean, requires_grad=False))
 
-        all_classes_ids = list(self.class_index_dict.values())
-        all_inds_ids = list(self.individual_index_dict.values())
-        
-        if epochs is None:
-            epochs = self.epochs
-        
-        for epoch in trange(epochs):
-            self.module.train()
-
-            train_loss = 0
-            loss = 0
-
-            for gci_name, gci_dataset in self.training_datasets.items():
-                if len(gci_dataset) == 0:
-                    continue
-
-                scores = th.mean(self.module(gci_dataset[:], gci_name)) 
-                loss += criterion(scores, th.zeros_like(scores, requires_grad=False))
-                
-                if gci_name == "gci2":
-                    idxs_for_negs = np.random.choice(all_classes_ids, size=len(gci_dataset), replace=True)
-                    rand_index = th.tensor(idxs_for_negs).to(self.device)
-                    data = gci_dataset[:]
-                    neg_data = th.cat([data[:, :2], rand_index.unsqueeze(1)], dim=1)
-                    scores = th.mean(self.module(neg_data, gci_name, neg=True)) 
-                    loss += criterion(scores, th.ones_like(scores, requires_grad=False))
-
-                if gci_name == "object_property_assertion":
-                    idxs_for_negs = np.random.choice(all_inds_ids, size=len(gci_dataset), replace=True)
-                    rand_index = th.tensor(idxs_for_negs).to(self.device)
-                    data = gci_dataset[:]
-                    neg_data = th.cat([data[:, :2], rand_index.unsqueeze(1)], dim=1)
-                    scores = th.mean(self.module(neg_data, gci_name, neg=True))
-                    loss += criterion(scores, th.ones_like(scores, requires_grad=False))
-                    
-            optimizer.zero_grad()
-            loss.backward()
-            optimizer.step()
-            train_loss += loss.detach().item()
-
-            loss = 0
-
-            if (epoch + 1) % validate_every == 0:
-                if self.dataset.validation is not None:
-                    with th.no_grad():
-                        self.module.eval()
-                        valid_loss = 0
-                        gci2_data = self.validation_datasets["gci2"][:]
-                        loss = th.mean(self.module(gci2_data, "gci2"))
-                        valid_loss += loss.detach().item()
+        return loss
 
 
-                        if valid_loss < best_loss:
-                            best_loss = valid_loss
-                            th.save(self.module.state_dict(), self.model_filepath)
-                    print(f'Epoch {epoch+1}: Train loss: {train_loss} Valid loss: {valid_loss}')
-                else:
-                    print(f'Epoch {epoch+1}: Train loss: {train_loss}')
- 
-    def eval_method(self, data):
-        return self.module.gci2_loss(data)
-
-    def get_embeddings(self):
-        self.init_module()
-
-        print('Load the best model', self.model_filepath)
-        self.load_best_model()
-                
-        ent_embeds = {
-            k: v for k, v in zip(self.class_index_dict.keys(),
-                                 self.module.class_embed.weight.cpu().detach().numpy())}
-        rel_embeds = {
-            k: v for k, v in zip(self.object_property_index_dict.keys(),
-                                 self.module.rel_embed.weight.cpu().detach().numpy())}
-        if self.module.ind_embed is not None:
-            ind_embeds = {
-                k: v for k, v in zip(self.individual_index_dict.keys(),
-                                     self.module.ind_embed.weight.cpu().detach().numpy())}
-        else:
-            ind_embeds = None
-        return ent_embeds, rel_embeds, ind_embeds
-
-    def load_best_model(self):
-        self.init_module()
-        self.module.load_state_dict(th.load(self.model_filepath))
-        self.module.eval()
-
-
-@deprecated(version='1.0.2', reason="Use ELBoxEmbeddings instead.")
-class ELBoxEmbeddings(ELBE):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
 

--- a/mowl/models/elembeddings/examples/model_gda.py
+++ b/mowl/models/elembeddings/examples/model_gda.py
@@ -9,6 +9,10 @@ class ELEmGDA(ELEmbeddings):
     with regularization inherited from ELEmbeddings.
     """
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.eval_gci_name = "gci2"
+
     def get_negative_sampling_config(self):
         """Only do negative sampling for gci2."""
         return {

--- a/mowl/models/elembeddings/examples/model_ppi.py
+++ b/mowl/models/elembeddings/examples/model_ppi.py
@@ -15,6 +15,7 @@ class ELEmPPI(ELEmbeddings):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.set_evaluator(PPIEvaluator)
+        self.eval_gci_name = "gci2"
         self._protein_ids = None
 
     @property

--- a/mowl/models/elembeddings/examples/model_ppi.py
+++ b/mowl/models/elembeddings/examples/model_ppi.py
@@ -1,87 +1,59 @@
-from mowl.base_models.elmodel import EmbeddingELModel
-from mowl.evaluation import PPIEvaluator
-from mowl.projection.factory import projector_factory
-from tqdm import trange, tqdm
-import torch as th
-
-import numpy as np
 from mowl.models import ELEmbeddings
+from mowl.evaluation import PPIEvaluator
+import torch as th
+import numpy as np
 
 
 class ELEmPPI(ELEmbeddings):
     """
     Example of ELEmbeddings for protein-protein interaction prediction.
+
+    This model customizes negative sampling to use only protein IDs
+    from the evaluation classes instead of all ontology classes.
     """
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-
         self.set_evaluator(PPIEvaluator)
+        self._protein_ids = None
+
+    @property
+    def protein_ids(self):
+        """Get protein IDs from evaluation classes (cached)."""
+        if self._protein_ids is None:
+            self._protein_ids = [
+                self.class_index_dict[p]
+                for p in self.dataset.evaluation_classes[0].as_str
+            ]
+        return self._protein_ids
 
     @property
     def evaluation_model(self):
         if self._evaluation_model is None:
             self._evaluation_model = self.module
-
         return self._evaluation_model
 
-    def train(self, validate_every=1000):
-        optimizer = th.optim.Adam(self.module.parameters(), lr=self.learning_rate)
-        best_loss = float("inf")
+    def get_negative_sampling_config(self):
+        """Only do negative sampling for gci2."""
+        return {
+            "gci2": {"corrupt_column": 2}
+        }
 
-        prots = [
-            self.class_index_dict[p] for p in self.dataset.evaluation_classes[0].as_str
-        ]
+    def generate_negatives(self, gci_name, gci_dataset):
+        """Generate negatives using only protein IDs for gci2."""
+        if gci_name != "gci2":
+            return None
 
-        for epoch in trange(self.epochs):
-            self.module.train()
-
-            train_loss = 0
-            loss = 0
-
-            for gci_name, gci_dataset in self.training_datasets.items():
-                if len(gci_dataset) == 0:
-                    continue
-
-                loss += th.mean(self.module(gci_dataset[:], gci_name))
-                if gci_name == "gci2":
-                    idxs_for_negs = np.random.choice(
-                        prots, size=len(gci_dataset), replace=True
-                    )
-                    rand_index = th.tensor(idxs_for_negs).to(self.device)
-                    data = gci_dataset[:]
-                    neg_data = th.cat([data[:, :2], rand_index.unsqueeze(1)], dim=1)
-                    loss += th.mean(self.module(neg_data, gci_name, neg=True))
-
-            loss += self.module.regularization_loss()
-
-            optimizer.zero_grad()
-            loss.backward()
-            optimizer.step()
-            train_loss += loss.detach().item()
-
-            loss = 0
-            with th.no_grad():
-                self.module.eval()
-                valid_loss = 0
-                gci2_data = self.validation_datasets["gci2"][:]
-                loss = th.mean(self.module(gci2_data, "gci2"))
-                valid_loss += loss.detach().item()
-
-            if (epoch + 1) % validate_every == 0:
-                if valid_loss < best_loss:
-                    best_loss = valid_loss
-                    th.save(self.module.state_dict(), self.model_filepath)
-                print(
-                    f"Epoch {epoch + 1}: Train loss: {train_loss} Valid loss: {valid_loss}"
-                )
-
-        return 1
-
-    def eval_method(self, data):
-        return self.module.gci2_score(data)
+        data = gci_dataset[:]
+        idxs_for_negs = np.random.choice(
+            self.protein_ids, size=len(gci_dataset), replace=True
+        )
+        rand_index = th.tensor(idxs_for_negs, dtype=th.long, device=self.device)
+        neg_data = th.cat([data[:, :2], rand_index.unsqueeze(1)], dim=1)
+        return neg_data
 
     def evaluate_ppi(self):
+        """Convenience method to evaluate PPI prediction."""
         self.init_module()
         print("Load the best model", self.model_filepath)
         self.load_best_model()

--- a/mowl/models/elembeddings/model.py
+++ b/mowl/models/elembeddings/model.py
@@ -1,14 +1,5 @@
 from mowl.base_models.elmodel import EmbeddingELModel
 from mowl.nn import ELEmModule
-from tqdm import trange, tqdm
-import torch as th
-import numpy as np
-import logging
-
-logger = logging.getLogger(__name__)
-handler = logging.StreamHandler()
-logger.addHandler(handler)
-logger.setLevel(logging.INFO)
 
 
 class ELEmbeddings(EmbeddingELModel):
@@ -21,25 +12,22 @@ class ELEmbeddings(EmbeddingELModel):
     work as loss functions in the optimization framework.
     """
 
-    
     def __init__(self,
                  dataset,
                  embed_dim=50,
                  margin=0,
                  reg_norm=1,
                  learning_rate=0.001,
-                 epochs=1000,
                  batch_size=4096 * 8,
                  model_filepath=None,
                  device='cpu'
                  ):
-        super().__init__(dataset, embed_dim, batch_size, extended=True, model_filepath=model_filepath)
+        super().__init__(dataset, embed_dim, batch_size, extended=True,
+                         model_filepath=model_filepath, device=device,
+                         learning_rate=learning_rate)
 
         self.margin = margin
         self.reg_norm = reg_norm
-        self.learning_rate = learning_rate
-        self.epochs = epochs
-        self.device = device
         self._loaded = False
         self.extended = False
         self.init_module()
@@ -52,102 +40,4 @@ class ELEmbeddings(EmbeddingELModel):
             embed_dim=self.embed_dim,
             margin=self.margin
         ).to(self.device)
-
-    def train(self, epochs=None, validate_every=1):
-        logger.warning('You are using the default training method. If you want to use a cutomized training method (e.g., different negative sampling, etc.), please reimplement the train method in a subclass.')
-
-        points_per_dataset = {k: len(v) for k, v in self.training_datasets.items()}
-        string = "Training datasets: \n"
-        for k, v in points_per_dataset.items():
-            string += f"\t{k}: {v}\n"
-
-        logger.info(string)
-            
-        optimizer = th.optim.Adam(self.module.parameters(), lr=self.learning_rate)
-        best_loss = float('inf')
-
-        all_classes_ids = list(self.class_index_dict.values())
-        all_inds_ids = list(self.individual_index_dict.values())
-        
-        if epochs is None:
-            epochs = self.epochs
-        
-        for epoch in trange(epochs):
-            self.module.train()
-
-            train_loss = 0
-            loss = 0
-
-            for gci_name, gci_dataset in self.training_datasets.items():
-                if len(gci_dataset) == 0:
-                    continue
-
-                loss += th.mean(self.module(gci_dataset[:], gci_name))
-                if gci_name == "gci2":
-                    idxs_for_negs = np.random.choice(all_classes_ids, size=len(gci_dataset), replace=True)
-                    rand_index = th.tensor(idxs_for_negs).to(self.device)
-                    data = gci_dataset[:]
-                    neg_data = th.cat([data[:, :2], rand_index.unsqueeze(1)], dim=1)
-                    loss += th.mean(self.module(neg_data, gci_name, neg=True))
-
-                if gci_name == "object_property_assertion":
-                    idxs_for_negs = np.random.choice(all_inds_ids, size=len(gci_dataset), replace=True)
-                    rand_index = th.tensor(idxs_for_negs).to(self.device)
-                    data = gci_dataset[:]
-                    neg_data = th.cat([data[:, :2], rand_index.unsqueeze(1)], dim=1)
-                    loss += th.mean(self.module(neg_data, gci_name, neg=True))
-                    
-            loss += self.module.regularization_loss()
-                    
-            optimizer.zero_grad()
-            loss.backward()
-            optimizer.step()
-            train_loss += loss.detach().item()
-
-            loss = 0
-
-            if (epoch + 1) % validate_every == 0:
-                if self.dataset.validation is not None:
-                    with th.no_grad():
-                        self.module.eval()
-                        valid_loss = 0
-                        gci2_data = self.validation_datasets["gci2"][:]
-                        loss = th.mean(self.module(gci2_data, "gci2"))
-                        valid_loss += loss.detach().item()
-
-
-                        if valid_loss < best_loss:
-                            best_loss = valid_loss
-                            th.save(self.module.state_dict(), self.model_filepath)
-                    print(f'Epoch {epoch+1}: Train loss: {train_loss} Valid loss: {valid_loss}')
-                else:
-                    print(f'Epoch {epoch+1}: Train loss: {train_loss}')
- 
-    def eval_method(self, data):
-        return self.module.gci2_loss(data)
-
-    def get_embeddings(self):
-        self.init_module()
-
-        print('Load the best model', self.model_filepath)
-        self.load_best_model()
-                
-        ent_embeds = {
-            k: v for k, v in zip(self.class_index_dict.keys(),
-                                 self.module.class_embed.weight.cpu().detach().numpy())}
-        rel_embeds = {
-            k: v for k, v in zip(self.object_property_index_dict.keys(),
-                                 self.module.rel_embed.weight.cpu().detach().numpy())}
-        if self.module.ind_embed is not None:
-            ind_embeds = {
-                k: v for k, v in zip(self.individual_index_dict.keys(),
-                                     self.module.ind_embed.weight.cpu().detach().numpy())}
-        else:
-            ind_embeds = None
-        return ent_embeds, rel_embeds, ind_embeds
-
-    def load_best_model(self):
-        self.init_module()
-        self.module.load_state_dict(th.load(self.model_filepath))
-        self.module.eval()
 

--- a/tests/evaluation/test_el.py
+++ b/tests/evaluation/test_el.py
@@ -16,9 +16,10 @@ class TestELModel(TestCase):
         self.ppi_dataset = PPIYeastSlimDataset()
 
     def test_evaluation_without_instantiating_evaluation_class(self):
-        model = ELEmPPI(self.ppi_dataset, epochs=1)
+        model = ELEmPPI(self.ppi_dataset)
+        model.eval_gci_name = "gci2"
         model.set_evaluator(PPIEvaluator)
-        model.train(validate_every=1)
+        model.train(epochs=1, validate_every=1)
         model.evaluate(
             self.ppi_dataset.testing, filter_ontologies=[self.ppi_dataset.ontology]
         )
@@ -28,10 +29,11 @@ class TestELModel(TestCase):
         self.assertTrue(mr > fmr)
 
     def test_evaluation_instantiating_evaluation_class(self):
-        model = ELEmPPI(self.ppi_dataset, epochs=1)
+        model = ELEmPPI(self.ppi_dataset)
+        model.eval_gci_name = "gci2"
         evaluator = PPIEvaluator(self.ppi_dataset)
         model.set_evaluator(evaluator)
-        model.train(validate_every=1)
+        model.train(epochs=1, validate_every=1)
         model.evaluate(
             self.ppi_dataset.testing, filter_ontologies=[self.ppi_dataset.ontology]
         )

--- a/tests/inductive/test_semantic_model.py
+++ b/tests/inductive/test_semantic_model.py
@@ -59,16 +59,15 @@ class TestSemanticModel(TestCase):
 
     def test_train_after_pretrained(self):
         first_model = ELEmPPI(
-            self.ppi_dataset, model_filepath="first_semantic_model", epochs=1
-        )
-        first_model.train(validate_every=1)
+            self.ppi_dataset, model_filepath="first_semantic_model")
+        first_model.train(epochs=1, validate_every=1)
 
         first_semantic_model = first_model.model_filepath
 
         self.assertTrue(os.path.exists(first_semantic_model))
 
-        second_model = ELEmPPI(self.ppi_dataset, epochs=1)
+        second_model = ELEmPPI(self.ppi_dataset)
         second_model.from_pretrained(first_semantic_model)
 
         self.assertNotEqual(second_model.model_filepath, first_semantic_model)
-        second_model.train()
+        second_model.train(epochs=1, validate_every=1)

--- a/tests/models/test_el_models.py
+++ b/tests/models/test_el_models.py
@@ -26,6 +26,7 @@ class TestELBE(TestCase):
     def test_elbe_train_ppi_dataset(self):
         """Test ELBE model can train on PPI dataset with validation"""
         model = ELBE(self.ppi_dataset, embed_dim=30)
+        model.eval_gci_name = "gci2"
         model.train(epochs=1, validate_every=1)
         self.assertTrue(True)
 
@@ -54,6 +55,7 @@ class TestELBEPPI(TestCase):
         Note: ELBEPPI automatically sets PPIEvaluator in __init__.
         """
         model = ELBEPPI(self.ppi_dataset, embed_dim=30)
+        model.eval_gci_name = "gci2"
         model.train(epochs=1, validate_every=1)
         model.evaluate(
             self.ppi_dataset.testing, filter_ontologies=[self.ppi_dataset.ontology]
@@ -127,5 +129,6 @@ class TestBoxSquaredEL(TestCase):
     def test_boxsquaredel_train_ppi_dataset(self):
         """Test BoxSquaredEL model can train on PPI dataset with validation"""
         model = BoxSquaredEL(self.ppi_dataset, embed_dim=30)
+        model.eval_gci_name = "gci2"
         model.train(epochs=1, validate_every=1)
         self.assertTrue(True)

--- a/tests/models/test_el_models.py
+++ b/tests/models/test_el_models.py
@@ -13,19 +13,19 @@ class TestELBE(TestCase):
 
     def test_elbe_initialization(self):
         """Test ELBE model can be initialized"""
-        model = ELBE(self.family_dataset, embed_dim=30, epochs=1)
+        model = ELBE(self.family_dataset, embed_dim=30)
         self.assertIsNotNone(model)
         self.assertIsNotNone(model.module)
 
     def test_elbe_train_family_dataset(self):
         """Test ELBE model can train on family dataset"""
-        model = ELBE(self.family_dataset, embed_dim=30, epochs=1)
+        model = ELBE(self.family_dataset, embed_dim=30)
         model.train(epochs=1)
         self.assertTrue(True)
 
     def test_elbe_train_ppi_dataset(self):
         """Test ELBE model can train on PPI dataset with validation"""
-        model = ELBE(self.ppi_dataset, embed_dim=30, epochs=1)
+        model = ELBE(self.ppi_dataset, embed_dim=30)
         model.train(epochs=1, validate_every=1)
         self.assertTrue(True)
 
@@ -39,22 +39,22 @@ class TestELBEPPI(TestCase):
 
     def test_elbeppi_initialization(self):
         """Test ELBEPPI model can be initialized"""
-        model = ELBEPPI(self.ppi_dataset, embed_dim=30, epochs=1)
+        model = ELBEPPI(self.ppi_dataset, embed_dim=30)
         self.assertIsNotNone(model)
         self.assertIsNotNone(model.module)
 
     def test_elbeppi_train(self):
         """Test ELBEPPI model can train"""
-        model = ELBEPPI(self.ppi_dataset, embed_dim=30, epochs=1)
-        model.train(validate_every=1)
+        model = ELBEPPI(self.ppi_dataset, embed_dim=30)
+        model.train(epochs=1, validate_every=1)
         self.assertTrue(True)
 
     def test_elbeppi_with_evaluator(self):
         """Test ELBEPPI model evaluation.
         Note: ELBEPPI automatically sets PPIEvaluator in __init__.
         """
-        model = ELBEPPI(self.ppi_dataset, embed_dim=30, epochs=1)
-        model.train(validate_every=1)
+        model = ELBEPPI(self.ppi_dataset, embed_dim=30)
+        model.train(epochs=1, validate_every=1)
         model.evaluate(
             self.ppi_dataset.testing, filter_ontologies=[self.ppi_dataset.ontology]
         )
@@ -73,16 +73,14 @@ class TestELBEGDA(TestCase):
 
     def test_elbegda_initialization(self):
         """Test ELBEGDA model can be initialized"""
-        model = ELBEGDA(self.gda_dataset, embed_dim=30, epochs=1)
+        model = ELBEGDA(self.gda_dataset, embed_dim=30)
         self.assertIsNotNone(model)
         self.assertIsNotNone(model.module)
 
     def test_elbegda_train(self):
-        """Test ELBEGDA model can train.
-        Note: ELBEGDA.train() uses self.epochs, so we set epochs=1 in constructor.
-        """
-        model = ELBEGDA(self.gda_dataset, embed_dim=30, epochs=1, batch_size=32)
-        model.train()
+        """Test ELBEGDA model can train."""
+        model = ELBEGDA(self.gda_dataset, embed_dim=30, batch_size=32)
+        model.train(epochs=1)
         self.assertTrue(True)
 
 
@@ -95,16 +93,14 @@ class TestELEmGDA(TestCase):
 
     def test_elemgda_initialization(self):
         """Test ELEmGDA model can be initialized"""
-        model = ELEmGDA(self.gda_dataset, embed_dim=30, epochs=1)
+        model = ELEmGDA(self.gda_dataset, embed_dim=30)
         self.assertIsNotNone(model)
         self.assertIsNotNone(model.module)
 
     def test_elemgda_train(self):
-        """Test ELEmGDA model can train.
-        Note: ELEmGDA.train() uses self.epochs, so we set epochs=1 in constructor.
-        """
-        model = ELEmGDA(self.gda_dataset, embed_dim=30, epochs=1)
-        model.train()
+        """Test ELEmGDA model can train."""
+        model = ELEmGDA(self.gda_dataset, embed_dim=30)
+        model.train(epochs=1)
         self.assertTrue(True)
 
 
@@ -118,18 +114,18 @@ class TestBoxSquaredEL(TestCase):
 
     def test_boxsquaredel_initialization(self):
         """Test BoxSquaredEL model can be initialized"""
-        model = BoxSquaredEL(self.family_dataset, embed_dim=30, epochs=1)
+        model = BoxSquaredEL(self.family_dataset, embed_dim=30)
         self.assertIsNotNone(model)
         self.assertIsNotNone(model.module)
 
     def test_boxsquaredel_train_family_dataset(self):
         """Test BoxSquaredEL model can train on family dataset"""
-        model = BoxSquaredEL(self.family_dataset, embed_dim=30, epochs=1)
+        model = BoxSquaredEL(self.family_dataset, embed_dim=30)
         model.train(epochs=1)
         self.assertTrue(True)
 
     def test_boxsquaredel_train_ppi_dataset(self):
         """Test BoxSquaredEL model can train on PPI dataset with validation"""
-        model = BoxSquaredEL(self.ppi_dataset, embed_dim=30, epochs=1)
+        model = BoxSquaredEL(self.ppi_dataset, embed_dim=30)
         model.train(epochs=1, validate_every=1)
         self.assertTrue(True)


### PR DESCRIPTION
Move generic training logic to EmbeddingELModel base class, allowing subclasses to customize behavior through hooks instead of duplicating the entire training loop.

New customization hooks in EmbeddingELModel:
- get_negative_sampling_config(): Configure which GCIs need negatives
- generate_negatives(): Custom negative sampling strategy
- compute_loss(): Custom loss computation (e.g., MSE loss for ELBE)
- get_regularization_loss(): Add regularization from module
- get_optimizer(): Use different optimizer

API changes:
- epochs parameter moved from __init__() to train()
- Subclasses now only need to implement init_module() and override hooks as needed

Models simplified:
- ELBE: Only overrides compute_loss() for MSE loss
- ELEmbeddings: Uses base class entirely (has regularization)
- BoxSquaredEL: Uses base class entirely (has regularization)

Example models updated to use new API:
- ELBEPPI, ELBEGDA
- ELEmPPI, ELEmGDA
- BoxSquaredELPPI, BoxSquaredELGDA

Code reduction: ~640 lines removed, ~450 lines added (net -190 lines)