### PR TITLE
Improve EL model and NN module test quality

### DIFF
--- a/tests/models/test_el_models.py
+++ b/tests/models/test_el_models.py
@@ -1,10 +1,20 @@
 from unittest import TestCase
+import torch as th
 from tests.datasetFactory import PPIYeastSlimDataset, FamilyDataset, GDAHumanELDataset
 from mowl.models import ELBE, ELBEPPI, ELBEGDA, ELEmGDA, BoxSquaredEL
 
 
+def _assert_trained(test_case, model, embed_dim):
+    """After any training run: parameters must be finite and have the right embedding dimension."""
+    first_param = next(model.module.parameters())
+    test_case.assertEqual(first_param.shape[-1], embed_dim)
+    test_case.assertTrue(
+        th.isfinite(first_param).all(),
+        "Model parameters contain NaN or Inf after training"
+    )
+
+
 class TestELBE(TestCase):
-    """Test the ELBE base model"""
 
     @classmethod
     def setUpClass(self):
@@ -12,102 +22,84 @@ class TestELBE(TestCase):
         self.ppi_dataset = PPIYeastSlimDataset()
 
     def test_elbe_initialization(self):
-        """Test ELBE model can be initialized"""
         model = ELBE(self.family_dataset, embed_dim=30)
         self.assertIsNotNone(model)
         self.assertIsNotNone(model.module)
 
     def test_elbe_train_family_dataset(self):
-        """Test ELBE model can train on family dataset"""
         model = ELBE(self.family_dataset, embed_dim=30)
         model.train(epochs=1)
-        self.assertTrue(True)
+        _assert_trained(self, model, embed_dim=30)
 
     def test_elbe_train_ppi_dataset(self):
-        """Test ELBE model can train on PPI dataset with validation"""
         model = ELBE(self.ppi_dataset, embed_dim=30)
         model.eval_gci_name = "gci2"
         model.train(epochs=1, validate_every=1)
-        self.assertTrue(True)
+        _assert_trained(self, model, embed_dim=30)
 
 
 class TestELBEPPI(TestCase):
-    """Test the ELBEPPI model for protein-protein interaction prediction"""
 
     @classmethod
     def setUpClass(self):
         self.ppi_dataset = PPIYeastSlimDataset()
 
     def test_elbeppi_initialization(self):
-        """Test ELBEPPI model can be initialized"""
         model = ELBEPPI(self.ppi_dataset, embed_dim=30)
         self.assertIsNotNone(model)
         self.assertIsNotNone(model.module)
 
     def test_elbeppi_train(self):
-        """Test ELBEPPI model can train"""
         model = ELBEPPI(self.ppi_dataset, embed_dim=30)
         model.train(epochs=1, validate_every=1)
-        self.assertTrue(True)
+        _assert_trained(self, model, embed_dim=30)
 
     def test_elbeppi_with_evaluator(self):
-        """Test ELBEPPI model evaluation.
-        Note: ELBEPPI automatically sets PPIEvaluator in __init__.
-        """
         model = ELBEPPI(self.ppi_dataset, embed_dim=30)
         model.eval_gci_name = "gci2"
         model.train(epochs=1, validate_every=1)
         model.evaluate(
             self.ppi_dataset.testing, filter_ontologies=[self.ppi_dataset.ontology]
         )
-
-        # Check that metrics are computed
         self.assertIn("mr", model.metrics)
         self.assertIn("f_mr", model.metrics)
 
 
 class TestELBEGDA(TestCase):
-    """Test the ELBEGDA model for gene-disease association prediction"""
 
     @classmethod
     def setUpClass(self):
         self.gda_dataset = GDAHumanELDataset()
 
     def test_elbegda_initialization(self):
-        """Test ELBEGDA model can be initialized"""
         model = ELBEGDA(self.gda_dataset, embed_dim=30)
         self.assertIsNotNone(model)
         self.assertIsNotNone(model.module)
 
     def test_elbegda_train(self):
-        """Test ELBEGDA model can train."""
         model = ELBEGDA(self.gda_dataset, embed_dim=30, batch_size=32)
         model.train(epochs=1)
-        self.assertTrue(True)
+        _assert_trained(self, model, embed_dim=30)
 
 
 class TestELEmGDA(TestCase):
-    """Test the ELEmGDA model for gene-disease association prediction"""
 
     @classmethod
     def setUpClass(self):
         self.gda_dataset = GDAHumanELDataset()
 
     def test_elemgda_initialization(self):
-        """Test ELEmGDA model can be initialized"""
         model = ELEmGDA(self.gda_dataset, embed_dim=30)
         self.assertIsNotNone(model)
         self.assertIsNotNone(model.module)
 
     def test_elemgda_train(self):
-        """Test ELEmGDA model can train."""
         model = ELEmGDA(self.gda_dataset, embed_dim=30)
         model.train(epochs=1)
-        self.assertTrue(True)
+        _assert_trained(self, model, embed_dim=30)
 
 
 class TestBoxSquaredEL(TestCase):
-    """Test the BoxSquaredEL model"""
 
     @classmethod
     def setUpClass(self):
@@ -115,20 +107,17 @@ class TestBoxSquaredEL(TestCase):
         self.ppi_dataset = PPIYeastSlimDataset()
 
     def test_boxsquaredel_initialization(self):
-        """Test BoxSquaredEL model can be initialized"""
         model = BoxSquaredEL(self.family_dataset, embed_dim=30)
         self.assertIsNotNone(model)
         self.assertIsNotNone(model.module)
 
     def test_boxsquaredel_train_family_dataset(self):
-        """Test BoxSquaredEL model can train on family dataset"""
         model = BoxSquaredEL(self.family_dataset, embed_dim=30)
         model.train(epochs=1)
-        self.assertTrue(True)
+        _assert_trained(self, model, embed_dim=30)
 
     def test_boxsquaredel_train_ppi_dataset(self):
-        """Test BoxSquaredEL model can train on PPI dataset with validation"""
         model = BoxSquaredEL(self.ppi_dataset, embed_dim=30)
         model.eval_gci_name = "gci2"
         model.train(epochs=1, validate_every=1)
-        self.assertTrue(True)
+        _assert_trained(self, model, embed_dim=30)

--- a/tests/nn/fixtures/elaxioms.py
+++ b/tests/nn/fixtures/elaxioms.py
@@ -1,8 +1,8 @@
 from tests.datasetFactory import FamilyDataset
 from mowl.owlapi import OWLAPIAdapter
-import random
 from mowl.owlapi.defaults import BOT
 import torch as th
+
 
 class ELAxioms():
 
@@ -14,11 +14,12 @@ class ELAxioms():
         self.classes = self.dataset.classes
         self.properties = self.dataset.object_properties
 
-        class_1 = random.choice(self.classes)
-        class_2 = random.choice(self.classes)
-        class_3 = random.choice(self.classes)
-        class_4 = random.choice(self.classes)
-        relation_1 = random.choice(self.properties)
+        # Use fixed indices so the fixture is deterministic across runs.
+        class_1 = self.classes[0]
+        class_2 = self.classes[1]
+        class_3 = self.classes[2]
+        class_4 = self.classes[3]
+        relation_1 = self.properties[0]
 
         class_1_id = self.dataset.class_to_id[class_1]
         class_2_id = self.dataset.class_to_id[class_2]
@@ -34,4 +35,3 @@ class ELAxioms():
         self.gci0_bot_data = th.LongTensor([[class_1_id, bot_id]])
         self.gci1_bot_data = th.LongTensor([[class_1_id, class_2_id, bot_id]])
         self.gci3_bot_data = th.LongTensor([[relation_1_id, class_1_id, bot_id]])
-        

--- a/tests/nn/test_boxsquaredel_module.py
+++ b/tests/nn/test_boxsquaredel_module.py
@@ -15,56 +15,39 @@ class TestBoxSquaredELModule(TestCase):
         self.module = BoxSquaredELModule(nb_classes, nb_rels, nb_inds)
         self.axioms = ELAxioms()
         
-    def test_gci_0(self):
-        """This should test the correct behavior of the module when the input is a GCI0"""
-
-        gci0 = self.axioms.gci0_data
-        result = self.module(gci0, "gci0")
+    def _assert_loss(self, result):
+        """Loss tensor must be finite and contain one value per sample in the batch."""
         self.assertIsInstance(result, th.Tensor)
+        self.assertEqual(result.numel(), 1)
+        self.assertTrue(th.isfinite(result).all(), "Loss contains NaN or Inf")
 
+    def test_gci_0(self):
+        result = self.module(self.axioms.gci0_data, "gci0")
+        self._assert_loss(result)
 
     def test_gci_1(self):
-        """This should test the correct behavior of the module when the input is a GCI1"""
-
-        gci1 = self.axioms.gci1_data
-        result = self.module(gci1, "gci1")
-        self.assertIsInstance(result, th.Tensor)
-
+        result = self.module(self.axioms.gci1_data, "gci1")
+        self._assert_loss(result)
 
     def test_gci_2(self):
-        """This should test the correct behavior of the module when the input is a GCI2"""
-
-        gci2 = self.axioms.gci2_data
-        result = self.module(gci2, "gci2")
-        self.assertIsInstance(result, th.Tensor)
+        result = self.module(self.axioms.gci2_data, "gci2")
+        self._assert_loss(result)
 
     def test_gci_3(self):
-        """This should test the correct behavior of the module when the input is a GCI3"""
-
-        gci3 = self.axioms.gci3_data
-        result = self.module(gci3, "gci3")
-        self.assertIsInstance(result, th.Tensor)
+        result = self.module(self.axioms.gci3_data, "gci3")
+        self._assert_loss(result)
 
     def test_gci_0_bot(self):
-        """This should test the correct behavior of the module when the input is a GCI0 with a bottom element"""
-
-        gci0_bot = self.axioms.gci0_bot_data
-        result = self.module(gci0_bot, "gci0_bot")
-        self.assertIsInstance(result, th.Tensor)
+        result = self.module(self.axioms.gci0_bot_data, "gci0_bot")
+        self._assert_loss(result)
 
     def test_gci_1_bot(self):
-        """This should test the correct behavior of the module when the input is a GCI1 with a bottom element"""
-
-        gci1_bot = self.axioms.gci1_bot_data
-        result = self.module(gci1_bot, "gci1_bot")
-        self.assertIsInstance(result, th.Tensor)
+        result = self.module(self.axioms.gci1_bot_data, "gci1_bot")
+        self._assert_loss(result)
 
     def test_gci_3_bot(self):
-        """This should test the correct behavior of the module when the input is a GCI3 with a bottom element"""
-
-        gci3_bot = self.axioms.gci3_bot_data
-        result = self.module(gci3_bot, "gci3_bot")
-        self.assertIsInstance(result, th.Tensor)
+        result = self.module(self.axioms.gci3_bot_data, "gci3_bot")
+        self._assert_loss(result)
 
         
 

--- a/tests/nn/test_elbe_module.py
+++ b/tests/nn/test_elbe_module.py
@@ -15,56 +15,39 @@ class TestELBEModule(TestCase):
         self.module = ELBEModule(nb_classes, nb_relations, nb_individuals)
         self.axioms = ELAxioms()
         
-    def test_gci_0(self):
-        """This should test the correct behavior of the module when the input is a GCI0"""
-
-        gci0 = self.axioms.gci0_data
-        result = self.module(gci0, "gci0")
+    def _assert_loss(self, result):
+        """Loss tensor must be finite and contain one value per sample in the batch."""
         self.assertIsInstance(result, th.Tensor)
+        self.assertEqual(result.numel(), 1)
+        self.assertTrue(th.isfinite(result).all(), "Loss contains NaN or Inf")
 
+    def test_gci_0(self):
+        result = self.module(self.axioms.gci0_data, "gci0")
+        self._assert_loss(result)
 
     def test_gci_1(self):
-        """This should test the correct behavior of the module when the input is a GCI1"""
-
-        gci1 = self.axioms.gci1_data
-        result = self.module(gci1, "gci1")
-        self.assertIsInstance(result, th.Tensor)
-
+        result = self.module(self.axioms.gci1_data, "gci1")
+        self._assert_loss(result)
 
     def test_gci_2(self):
-        """This should test the correct behavior of the module when the input is a GCI2"""
-
-        gci2 = self.axioms.gci2_data
-        result = self.module(gci2, "gci2")
-        self.assertIsInstance(result, th.Tensor)
+        result = self.module(self.axioms.gci2_data, "gci2")
+        self._assert_loss(result)
 
     def test_gci_3(self):
-        """This should test the correct behavior of the module when the input is a GCI3"""
-
-        gci3 = self.axioms.gci3_data
-        result = self.module(gci3, "gci3")
-        self.assertIsInstance(result, th.Tensor)
+        result = self.module(self.axioms.gci3_data, "gci3")
+        self._assert_loss(result)
 
     def test_gci_0_bot(self):
-        """This should test the correct behavior of the module when the input is a GCI0 with a bottom element"""
-
-        gci0_bot = self.axioms.gci0_bot_data
-        result = self.module(gci0_bot, "gci0_bot")
-        self.assertIsInstance(result, th.Tensor)
+        result = self.module(self.axioms.gci0_bot_data, "gci0_bot")
+        self._assert_loss(result)
 
     def test_gci_1_bot(self):
-        """This should test the correct behavior of the module when the input is a GCI1 with a bottom element"""
-
-        gci1_bot = self.axioms.gci1_bot_data
-        result = self.module(gci1_bot, "gci1_bot")
-        self.assertIsInstance(result, th.Tensor)
+        result = self.module(self.axioms.gci1_bot_data, "gci1_bot")
+        self._assert_loss(result)
 
     def test_gci_3_bot(self):
-        """This should test the correct behavior of the module when the input is a GCI3 with a bottom element"""
-
-        gci3_bot = self.axioms.gci3_bot_data
-        result = self.module(gci3_bot, "gci3_bot")
-        self.assertIsInstance(result, th.Tensor)
+        result = self.module(self.axioms.gci3_bot_data, "gci3_bot")
+        self._assert_loss(result)
 
         
 

--- a/tests/nn/test_elem_module.py
+++ b/tests/nn/test_elem_module.py
@@ -15,56 +15,39 @@ class TestELEmModule(TestCase):
         self.module = ELEmModule(nb_classes, nb_relations, nb_individuals)
         self.axioms = ELAxioms()
         
-    def test_gci_0(self):
-        """This should test the correct behavior of the module when the input is a GCI0"""
-
-        gci0 = self.axioms.gci0_data
-        result = self.module(gci0, "gci0")
+    def _assert_loss(self, result):
+        """Loss tensor must be finite and contain one value per sample in the batch."""
         self.assertIsInstance(result, th.Tensor)
+        self.assertEqual(result.numel(), 1)
+        self.assertTrue(th.isfinite(result).all(), "Loss contains NaN or Inf")
 
+    def test_gci_0(self):
+        result = self.module(self.axioms.gci0_data, "gci0")
+        self._assert_loss(result)
 
     def test_gci_1(self):
-        """This should test the correct behavior of the module when the input is a GCI1"""
-
-        gci1 = self.axioms.gci1_data
-        result = self.module(gci1, "gci1")
-        self.assertIsInstance(result, th.Tensor)
-
+        result = self.module(self.axioms.gci1_data, "gci1")
+        self._assert_loss(result)
 
     def test_gci_2(self):
-        """This should test the correct behavior of the module when the input is a GCI2"""
-
-        gci2 = self.axioms.gci2_data
-        result = self.module(gci2, "gci2")
-        self.assertIsInstance(result, th.Tensor)
+        result = self.module(self.axioms.gci2_data, "gci2")
+        self._assert_loss(result)
 
     def test_gci_3(self):
-        """This should test the correct behavior of the module when the input is a GCI3"""
-
-        gci3 = self.axioms.gci3_data
-        result = self.module(gci3, "gci3")
-        self.assertIsInstance(result, th.Tensor)
+        result = self.module(self.axioms.gci3_data, "gci3")
+        self._assert_loss(result)
 
     def test_gci_0_bot(self):
-        """This should test the correct behavior of the module when the input is a GCI0 with a bottom element"""
-
-        gci0_bot = self.axioms.gci0_bot_data
-        result = self.module(gci0_bot, "gci0_bot")
-        self.assertIsInstance(result, th.Tensor)
+        result = self.module(self.axioms.gci0_bot_data, "gci0_bot")
+        self._assert_loss(result)
 
     def test_gci_1_bot(self):
-        """This should test the correct behavior of the module when the input is a GCI1 with a bottom element"""
-
-        gci1_bot = self.axioms.gci1_bot_data
-        result = self.module(gci1_bot, "gci1_bot")
-        self.assertIsInstance(result, th.Tensor)
+        result = self.module(self.axioms.gci1_bot_data, "gci1_bot")
+        self._assert_loss(result)
 
     def test_gci_3_bot(self):
-        """This should test the correct behavior of the module when the input is a GCI3 with a bottom element"""
-
-        gci3_bot = self.axioms.gci3_bot_data
-        result = self.module(gci3_bot, "gci3_bot")
-        self.assertIsInstance(result, th.Tensor)
+        result = self.module(self.axioms.gci3_bot_data, "gci3_bot")
+        self._assert_loss(result)
 
         
 


### PR DESCRIPTION
## Summary

- Replace `assertTrue(True)` stubs in EL model training tests with real assertions: embedding shape (`embed_dim=30`) and finiteness (no NaN/Inf) after 1 epoch
- Add `numel` and `isfinite` checks to all `ELEm`, `ELBE`, and `BoxSquaredEL` module tests (previously only checked `assertIsInstance`)
- Make `ELAxioms` fixture deterministic by replacing `random.choice` with fixed indices — removes a source of non-determinism within tests

**Note:** while reading the loss functions, noticed that output shapes are inconsistent across GCI types (`gci0_loss` returns `(batch, 1)`, `gci0_bot_loss` returns `(batch,)`). Tests use `numel()` to handle both. Worth fixing in a follow-up.

## Test plan

- [ ] `pytest tests/models/ tests/nn/ -m "not slow"` passes
- [ ] No `assertTrue(True)` remaining in model training tests