### PR TITLE
Add git-cliff changelog tooling and document BoxEL model

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,0 +1,35 @@
+name: Changelog
+
+on:
+  pull_request:
+    branches: [ "main", "develop" ]
+
+jobs:
+  changelog:
+    # Dependabot cannot edit CHANGELOG.md, so don't block its PRs.
+    if: github.actor != 'dependabot[bot]'
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Install git-cliff
+        run: pip install git-cliff
+
+      - name: Validate cliff.toml
+        run: git-cliff --unreleased
+
+      - name: Ensure [Unreleased] has entries
+        run: |
+          section=$(awk '/^## \[Unreleased\]/{flag=1; next} /^## \[/{flag=0} flag' CHANGELOG.md)
+          if ! echo "$section" | grep -q '^- '; then
+            echo "::error file=CHANGELOG.md::The [Unreleased] section is empty. Run 'git-cliff --unreleased' to draft entries, then polish them in CHANGELOG.md."
+            exit 1
+          fi
+          echo "[Unreleased] section has entries."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Added `BoxEL` model (with `BoxELPPI` and `BoxELGDA` examples) wrapping `BoxELModule` [#70][i70].
+- Added 2-D geometric EL visualizers for ELEm, ELBE, and Box²EL, plus a role-visualization API showing Box²EL relation pairs.
+- Added an `epoch_callback` argument to `train()` and a geometric EL training animation gallery example.
+- Exposed `neg_sampling_gcis` in `ELEmbeddings`, `ELBE`, and `BoxSquaredEL`.
+- Added tests for all 13 previously untested `OWLAPIAdapter` methods.
+### Changed
+- Documented the available EL models (`ELEmbeddings`, `ELBE`, `BoxSquaredEL`, `BoxEL`) in the embedding guide.
+- Replaced the interactive jshtml animation with an autoplaying GIF in the gallery and docs.
+- Bumped CI GitHub Actions (setup-java, setup-python, checkout, upload-artifact, download-artifact, github-script, sigstore, conda setup-miniconda).
+### Removed
+- Removed ontology load caches that polluted shared test fixtures.
 
 ## [2.0.0] - 2026-05-12
 ### Added
@@ -161,5 +173,6 @@ Fixed issue related to importing graph-based models due to missing `__init__.py`
 [i43]: https://github.com/bio-ontology-research-group/mowl/issues/43
 [i59]: https://github.com/bio-ontology-research-group/mowl/issues/59
 [i60]: https://github.com/bio-ontology-research-group/mowl/issues/60
+[i70]: https://github.com/bio-ontology-research-group/mowl/issues/70
 [i97]: https://github.com/bio-ontology-research-group/mowl/issues/97
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,6 +66,7 @@ The version is derived from git tags via `setuptools_scm` — **do not set versi
 
 1. **Merge** all pending PRs (feature branches) into `main`.
 2. **Update `CHANGELOG.md`**: rename `[Unreleased]` to `[X.Y.Z]` with today's date. Add a new empty `[Unreleased]` section at the top. Update the comparison link at the bottom.
+   - To draft the entries from git history, run `git-cliff --unreleased` (config in `cliff.toml`). It groups commits into Keep a Changelog sections by their leading verb (Add/Fix/Remove/...). Treat the output as a **draft**: polish wording and add issue links (`[#NN][iNN]`) by hand. Install with `pip install git-cliff`.
 3. **Update `docs/source/conf.py`**: set `release` and `version` to `X.Y.Z`.
 4. **Commit** the above two files:
    ```bash

--- a/cliff.toml
+++ b/cliff.toml
@@ -1,0 +1,57 @@
+# git-cliff configuration for mOWL
+#
+# Generates Keep a Changelog-style entries from git history. mOWL does NOT use
+# Conventional Commits, so commits are grouped by their imperative-mood verb
+# (Add/Fix/Remove/...) instead of `feat:`/`fix:` prefixes.
+#
+# Usage:
+#   git-cliff --unreleased                     # preview entries since last tag
+#   git-cliff --unreleased --prepend CHANGELOG.md   # draft them into the file
+#   git-cliff --tag vX.Y.Z -o CHANGELOG.md     # regenerate the whole file
+#
+# The generated text is a *draft*: refine wording and add issue links by hand
+# before release (see the release checklist in CLAUDE.md).
+
+[changelog]
+header = """
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+"""
+body = """
+{% if version %}\
+    ## [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
+{% else %}\
+    ## [Unreleased]
+{% endif %}\
+{% for group, commits in commits | group_by(attribute="group") %}
+### {{ group | striptags | trim | upper_first }}
+{% for commit in commits %}
+- {{ commit.message | split(pat="\n") | first | upper_first }}\
+{% endfor %}
+{% endfor %}\n
+"""
+footer = ""
+trim = true
+
+[git]
+conventional_commits = false
+filter_unconventional = false
+split_commits = false
+# Group commits into Keep a Changelog sections by their leading verb.
+# The `<!-- N -->` prefixes only control section ordering and are stripped in
+# the template via `striptags`.
+commit_parsers = [
+  { message = "^[Mm]erge ", skip = true },
+  { message = "^(Add|Added|Expose|Introduce|Implement|Support|Enable|Create)", group = "<!-- 0 -->Added" },
+  { message = "^(Deprecate)", group = "<!-- 2 -->Deprecated" },
+  { message = "^(Remove|Removed|Delete|Drop)", group = "<!-- 3 -->Removed" },
+  { message = "^(Fix|Fixed|Correct)", group = "<!-- 4 -->Fixed" },
+  { message = ".*", group = "<!-- 1 -->Changed" },
+]
+filter_commits = false
+tag_pattern = "v[0-9]*"
+sort_commits = "oldest"

--- a/docs/source/embedding_el/index.rst
+++ b/docs/source/embedding_el/index.rst
@@ -287,7 +287,16 @@ To see actual examples of EL models, let's go to |tutorial_elembeddings| and |tu
 Just use a mOWL model
 ------------------------
 
-We have seen that constructing a |el| model has many steps. However, the main difference between them, is the definition of loss functions and the training loop. Therefore, using the :class:`ELEmbeddingModel <mowl.base_models.elmodel.EmbeddingELModel>` can be useful by just defining the training loop. Here is an example of using ELEmbeddings for protein-protein interaction prediction:
+We have seen that constructing a |el| model has many steps. However, the main difference between them, is the definition of loss functions and the training loop. Therefore, using the :class:`ELEmbeddingModel <mowl.base_models.elmodel.EmbeddingELModel>` can be useful by just defining the training loop.
+
+mOWL ships several ready-to-use :math:`\mathcal{EL}` models that share this interface, so they can be swapped in without changing the surrounding code:
+
+- :class:`ELEmbeddings <mowl.models.ELEmbeddings>` — classes as balls [kulmanov2019]_
+- :class:`ELBE <mowl.models.ELBE>` — classes as axis-aligned boxes [peng2020]_
+- :class:`BoxSquaredEL <mowl.models.BoxSquaredEL>` — boxes with bumps for relations (Box²EL) [jackermeier2023]_
+- :class:`BoxEL <mowl.models.BoxEL>` — box embeddings for EL++ knowledge bases [xiong2022]_
+
+Here is an example of using ELEmbeddings for protein-protein interaction prediction:
 
 .. testcode::
 


### PR DESCRIPTION
## Summary

Sets up changelog automation and closes documentation/housekeeping gaps found after the v2.0.0 release.

### Changelog tooling (git-cliff)
- Add `cliff.toml`, configured for mOWL's imperative-mood commits (the repo doesn't use Conventional Commits) — groups commits into Keep a Changelog sections by their leading verb (Add/Fix/Remove/...). Validated against real history.
- Fill the previously **empty** `[Unreleased]` section with post-2.0.0 work: BoxEL model, EL visualizers, `epoch_callback`, `OWLAPIAdapter` tests, CI action bumps.
- Add `.github/workflows/changelog.yml`: validates `cliff.toml` and fails a PR if `[Unreleased]` is empty (skipped for dependabot, which can't edit the changelog).
- Document the `git-cliff` drafting workflow in the release checklist (`CLAUDE.md`).

### BoxEL docs
- The BoxEL model (`mowl.models.BoxEL`, merged in #132) was absent from the narrative docs. Added a list of available EL models — `ELEmbeddings`, `ELBE`, `BoxSquaredEL`, `BoxEL` — with cross-refs and citations to `docs/source/embedding_el/index.rst`. (The API reference page is auto-generated by `automodapi`.)

## Notes
- `make doctest` already runs in CI (`docs-doctest.yml`) and will validate the new cross-refs on this PR.
- git-cliff is configured as a **drafting aid**, not an auto-committing bot, to preserve the hand-curated changelog (issue links, polished wording).

## Follow-ups (not in this PR)
- Optional gallery tutorial for BoxEL (`plot_4_boxel.py`), like the other EL models.